### PR TITLE
Removes deprecated html tag <center> in base template

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -84,6 +84,15 @@ a:hover, a:focus, a:active, a:visited {
 }
 
 /* div class */
+
+.flex {
+    display: flex;
+}
+
+.flex.justify-content-center {
+    justify-content: center;
+}
+
 .about {
 	padding: 20px;
 	margin-top: 20px;

--- a/template/index.html
+++ b/template/index.html
@@ -14,10 +14,8 @@
     
 <body>
 
- <div class="main">
-    
-   <center>
-       
+ <div class="main">    
+   <div class="flex justify-content-center">       
         <div class="about">
             <img src="img/default.png" class="main-img">
             <h3><span>Vinit</span></h3>
@@ -37,12 +35,9 @@
               <li><a href="#"><i class="fa fa-github"></i></a></li>
             </ul>
             
-          </div>
-       
-    </center>
-    
- </div>
-    
+          </div>       
+    </div>    
+ </div>    
 </body>
     
 <!--- Made with love by Vinit Shahdeo -->


### PR DESCRIPTION
This is just to remove the `<center>` tag that was bugging me in the template since it is no longer a valid HTML5 tag ;) I didn't touch anything else.